### PR TITLE
[BUGFIX] Ensure TestCommand::execute() interface compatibility

### DIFF
--- a/Classes/Command/TestCommand.php
+++ b/Classes/Command/TestCommand.php
@@ -36,7 +36,7 @@ class TestCommand extends Command
     /**
      * @inheritdoc
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 


### PR DESCRIPTION
This PR fixes the following issue:

```
Fatal error: Declaration of
StudioMitte\Brevo\Command\TestCommand::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output)
must be compatible with 
Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int
in /var/www/html/vendor/studiomitte/brevo/Classes/Command/TestCommand.php on line 39
```